### PR TITLE
Fix conflict with importexport module

### DIFF
--- a/code/ModelAdmin/SEOEditorAdmin.php
+++ b/code/ModelAdmin/SEOEditorAdmin.php
@@ -132,8 +132,10 @@ class SEOEditorAdmin extends ModelAdmin
         $form = parent::ImportForm();
         $modelName = $this->modelClass;
 
-        $form->Fields()->removeByName("SpecFor{$modelName}");
-        $form->Fields()->removeByName("EmptyBeforeImport");
+        if ($form) {        
+            $form->Fields()->removeByName("SpecFor{$modelName}");
+            $form->Fields()->removeByName("EmptyBeforeImport");
+        }
 
         return $form;
     }


### PR DESCRIPTION
Check if the form is set before accessing the Fields method, this issue was due to a conflict with the burnbright/silverstripe-importexport module.
